### PR TITLE
Get Lat Long Data from Polygon Creation

### DIFF
--- a/snow/src/components/map/MapComponent.tsx
+++ b/snow/src/components/map/MapComponent.tsx
@@ -126,9 +126,12 @@ const MapComponent: React.FC<MapComponentProps> = ({
     startDrawing();
 
     // Remove the draw interaction once polygon has been created
-    draw.on("drawend", () => {
+    draw.on("drawend", (event) => {
       map.removeInteraction(draw);
-      stopDrawing();
+      stopDrawing()
+      // Outputs long lat, not lat long.
+      const polygonCoordinates = event.feature?.getGeometry()?.getCoordinates();
+      console.log("Polygon Coordinates", polygonCoordinates);
       onPolygonComplete();
     });
   };
@@ -192,6 +195,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
     stopDrawing();
     stopModifying();
   }
+
 
   return (
     <>


### PR DESCRIPTION
**Information on the way OpenLayers handles coordinates:**

- The coordinates are Long Lat, _NOT_ Lat Long.
- By default, OpenLayers uses the Web Mercator projection (EPSG:3857) to render objects.
- The documentation says the output of getCoordinates is an array that has the same structure as GeoJSON.
- OpenLayers is able to convert map projections, it sounds like it must be converted to EPSG:3857 to render.

Possibly useful resources:
- https://openlayers.org/en/latest/apidoc/module-ol_geom_Polygon-Polygon.html (Specifically the getCoordinates() function.)
- https://stackoverflow.com/questions/59049617/openlayers-geojson-and-coordinates
- https://openlayers.org/en/latest/apidoc/module-ol_format_GeoJSON-GeoJSON.html
- https://openlayers.org/doc/faq.html
